### PR TITLE
Modified line that calculates unique domains

### DIFF
--- a/docker/oc-deploy-certs.sh
+++ b/docker/oc-deploy-certs.sh
@@ -94,7 +94,7 @@ objects:
 EOF
 
 #Prepare list of domains
-oc get route -l certbot-managed=true -o json | jq '.items[].spec.host' -r | sort -f | uniq -iu > /tmp/certbot-hosts.txt
+oc get route -l certbot-managed=true -o json | jq '.items[].spec.host' -r | sort -f | uniq -i > /tmp/certbot-hosts.txt
 cat /tmp/certbot-hosts.txt | paste -sd "," - > /tmp/certbot-hosts.csv
 
 echo 'CERTBOT_DEBUG =' $CERTBOT_DEBUG


### PR DESCRIPTION
the call to uniq  on https://github.com/franTarkenton/certbot/blob/74a4d17edf4f83a468ff23565ea0874ec5dfa30a/docker/oc-deploy-certs.sh#L97 
will not return any domains if there are more than one route with the same domain.