### PR TITLE
Add Helm chart

### DIFF
--- a/.github/workflows/charts-release.yml
+++ b/.github/workflows/charts-release.yml
@@ -1,0 +1,30 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.3.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/charts-release.yml
+++ b/.github/workflows/charts-release.yml
@@ -2,6 +2,8 @@ name: Release Charts
 
 on:
   push:
+    paths:
+      - 'charts/**'
     branches:
       - master
 

--- a/.github/workflows/charts-release.yml
+++ b/.github/workflows/charts-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -22,11 +22,11 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v2
         with:
-          version: v3.7.1
+          version: v3.8.2
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.3.0
+        uses: helm/chart-releaser-action@v1.4.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+chart/**/charts
+
+.vscode/

--- a/chart/certbot/.helmignore
+++ b/chart/certbot/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/certbot/Chart.yaml
+++ b/chart/certbot/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: certbot
+description: A Helm chart for the Common Services Certbot
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/chart/certbot/README.md
+++ b/chart/certbot/README.md
@@ -111,3 +111,14 @@ spec:
 ## Artifactory Usage
 
 If you want to use Artifactory's local caching to download the docker image, you can set `artifactoryProxy.enabled: true` and provide the name of your `ArtifactoryServiceAccount` with `artifactoryProxy.artifactoryServiceAccount`. The chart will then add your artifactory pull secret to the job's `imagePullSecrets`.
+
+## Usage with Entrust
+
+When issuing certificate using the Entrust ACME server, you may want to keep the server URL in a Secret. The `certbot.server` supports this by allowing either a string, or the following object:
+
+```yaml
+certbot:
+  server:
+    secretName: your-acme-server-secret
+    secretKey: acme-server-url
+```

--- a/chart/certbot/README.md
+++ b/chart/certbot/README.md
@@ -1,0 +1,113 @@
+# Certbot helm chart
+
+A Reusable [Helm](https://helm.sh/) chart for the Certbot docker container.
+
+## Installation
+
+### You are deploying your application with Helm
+
+If you have one application per namespace, it might make sense to have certbot as a dependency of the application, so that SSL certificate issuance is done when the application is installed, thanks to the `manualRun: true` option.
+
+1. Add certbot as a dependency in your `Chart.yaml`
+
+```yaml
+dependencies:
+  - name: certbot
+    version: 0.1.0
+    repository: https://bcdevops.github.io/certbot
+```
+
+In your application's `values.yaml`, you can then override the Certbot chart settings, e.g.:
+
+```yaml
+certbot:
+  image:
+    tag: 1.0.0
+    pullPolicy: IfNotPresent
+  certbot:
+    email: your.email@gov.bc.ca
+```
+
+2. Update your application (don't forget to update your helm dependencies with `helm dep up`)
+
+### You are not deploying your application with Helm
+
+If this is your first time using helm, check out the [quickstart guide](https://helm.sh/docs/intro/quickstart/). The steps below are similar to the one from the quickstart guide, but specifically for this chart
+
+`$ helm repo add certbot https://bcdevops.github.io/certbot`
+
+Once the repo is added, you can check the available charts with:
+
+```
+$ helm search repo certbot
+NAME                CHART VERSION   APP VERSION
+certbot/certbot     0.1.0           1.0.0
+```
+
+Then, install an instance of the chart with:
+
+```
+$ helm install -n my-namespace my-certbot certbot/certbot --set certbot.email=your.email@gov.bc.ca
+
+NAME: my-certbot
+LAST DEPLOYED: Mon Feb 28 15:38:32 2022
+NAMESPACE: my-namespace
+STATUS: deployed
+REVISION: 1
+```
+
+You can use the `--set` or `--values` option to change the default configuration.
+
+## Deletion
+
+`helm -n my-namespace delete my-certbot`
+
+## Configuration and default behaviour
+
+You can find an exhaustive list of the configurable settings in `values.yaml`.
+
+## Helm-managed routes with Certbot
+
+If you are using Helm to deploy your application, you likely create the routes via helm as well. Certbot will inject the `tls` settings in your route after Helm creates it, so you need to ensure that Helm does not overwrite the changes that Certbot made next time it updates your route (unless you change the host and actually need to issue a new certificate).
+The example below uses Helm's `lookup` function to retrieve the certificates and key from the route before recreating the template.
+
+```yaml
+{{- $route := (lookup "route.openshift.io/v1" "Route" .Release.Namespace "your-route" ) }}
+{{- $certificate := "" }}
+{{- $key := "" }}
+{{- $caCertificate := "" }}
+{{- if $route }}
+{{- $certificate = $route.spec.tls.certificate }}
+{{- $key = $route.spec.tls.key }}
+{{- $caCertificate = $route.spec.tls.caCertificate }}
+{{- end -}}
+
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: your-route
+  labels: {{ include "your-chart.labels" . | nindent 4 }}
+    certbot-managed: "true"
+
+spec:
+  host: your-host.gov.bc.ca
+  port:
+    targetPort: your-port
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+    {{- if $route }}
+    certificate: {{ $certificate | quote }}
+    key: {{ $key | quote }}
+    caCertificate: {{ $caCertificate | quote }}
+    {{- end }}
+  to:
+    kind: Service
+    name: your-service
+    weight: 100
+  wildcardPolicy: None
+```
+
+## Artifactory Usage
+
+If you want to use Artifactory's local caching to download the docker image, you can set `artifactoryProxy.enabled: true` and provide the name of your `ArtifactoryServiceAccount` with `artifactoryProxy.artifactoryServiceAccount`. The chart will then add your artifactory pull secret to the job's `imagePullSecrets`.

--- a/chart/certbot/templates/_helpers.tpl
+++ b/chart/certbot/templates/_helpers.tpl
@@ -1,0 +1,126 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "certbot.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "certbot.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "certbot.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "certbot.labels" -}}
+helm.sh/chart: {{ include "certbot.chart" . }}
+{{ include "certbot.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "certbot.selectorLabels" -}}
+app: {{ include "certbot.name" . }}
+app.kubernetes.io/name: {{ include "certbot.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "certbot.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "certbot.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "certbot.artifactoryPullSecret" }}
+{{- $artSa := (lookup "artifactory.devops.gov.bc.ca/v1alpha1" "ArtifactoryServiceAccount" .Release.Namespace .Values.artifactoryProxy.artifactoryServiceAccount) }}
+{{- if $artSa.spec }}
+- name: artifacts-pull-{{ .Values.artifactoryProxy.artifactoryServiceAccount }}-{{ $artSa.spec.current_plate }}
+{{- else }}
+{{/*
+When running helm template, or using --dry-run, lookup returns an empty object
+*/}}
+- name: image-pull-secret-here
+{{- end }}
+{{- end }}
+
+{{- define "certbot.jobSpec" }}
+backoffLimit: 6
+activeDeadlineSeconds: 300
+parallelism: 1
+completions: 1
+template:
+  metadata:
+    labels: {{ include "certbot.labels" . | nindent 6 }}
+  spec:
+    {{- if .Values.artifactoryProxy.enabled }}
+    imagePullSecrets: {{ include "certbot.artifactoryPullSecret" . | nindent 6 }}
+    {{- end }}
+    containers:
+      - name: certbot
+        {{- if .Values.artifactoryProxy.enabled }}
+        image: "{{ .Values.artifactoryProxy.artifactoryPrefix }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- else }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          - name: CERTBOT_DEBUG
+            value: {{ .Values.certbot.debug  | quote }}
+          - name: CERTBOT_DELETE_ACME_ROUTES
+            value: {{ .Values.certbot.deleteAcmeRoutes | quote }}
+          - name: CERTBOT_DRY_RUN
+            value: {{ .Values.certbot.dryRun | quote }}
+          - name: CERTBOT_EMAIL
+            value: {{ .Values.certbot.email | quote }}
+          - name: CERTBOT_SERVER
+            value: {{ .Values.certbot.server }}
+          - name: CERTBOT_STAGING
+            value: {{ .Values.certbot.staging | quote }}
+          - name: CERTBOT_SUBSET
+            value: {{ .Values.certbot.subset | quote }}
+        resources:
+          requests:
+            cpu: 50m
+          limits:
+            cpu: 250m
+        volumeMounts:
+          - mountPath: /etc/letsencrypt
+            name: certbot-config
+    restartPolicy: Never
+    serviceAccountName: certbot
+    volumes:
+      - name: certbot-config
+        persistentVolumeClaim:
+          claimName: {{ template "certbot.fullname" . }}
+{{- end }}

--- a/chart/certbot/templates/_helpers.tpl
+++ b/chart/certbot/templates/_helpers.tpl
@@ -104,7 +104,14 @@ template:
           - name: CERTBOT_EMAIL
             value: {{ .Values.certbot.email | quote }}
           - name: CERTBOT_SERVER
+            {{- if kindIs "string" .Values.certbot.server }}
             value: {{ .Values.certbot.server }}
+            {{- else }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.certbot.server.secretName }}
+                key: {{ .Values.certbot.server.secretKey }}
+            {{- end }}
           - name: CERTBOT_STAGING
             value: {{ .Values.certbot.staging | quote }}
           - name: CERTBOT_SUBSET

--- a/chart/certbot/templates/_helpers.tpl
+++ b/chart/certbot/templates/_helpers.tpl
@@ -62,6 +62,9 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{- /*
+  The artifactory image pull secret to use, retrieved from the provided ArtifactoryServiceAccount
+  */}}
 {{- define "certbot.artifactoryPullSecret" }}
 {{- $artSa := (lookup "artifactory.devops.gov.bc.ca/v1alpha1" "ArtifactoryServiceAccount" .Release.Namespace .Values.artifactoryProxy.artifactoryServiceAccount) }}
 {{- if $artSa.spec }}
@@ -74,6 +77,9 @@ When running helm template, or using --dry-run, lookup returns an empty object
 {{- end }}
 {{- end }}
 
+{{- /*
+  A reuseable job spec, used in both the cron and batch job templates.
+  */}}
 {{- define "certbot.jobSpec" }}
 backoffLimit: 6
 activeDeadlineSeconds: 300

--- a/chart/certbot/templates/_helpers.tpl
+++ b/chart/certbot/templates/_helpers.tpl
@@ -102,7 +102,7 @@ template:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: CERTBOT_DEBUG
-            value: {{ .Values.certbot.debug  | quote }}
+            value: {{ .Values.certbot.debug | quote }}
           - name: CERTBOT_DELETE_ACME_ROUTES
             value: {{ .Values.certbot.deleteAcmeRoutes | quote }}
           - name: CERTBOT_DRY_RUN

--- a/chart/certbot/templates/cronjob.yaml
+++ b/chart/certbot/templates/cronjob.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ template "certbot.fullname" . }}
+  labels: {{ include "certbot.labels" . | nindent 4 }}
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  startingDeadlineSeconds: 60
+  jobTemplate:
+    metadata:
+      labels: {{ include "certbot.labels" . | nindent 8 }}
+    spec: {{ include "certbot.jobSpec" . | nindent 6 }}
+  schedule: {{ .Values.cron.schedule }}
+  suspend: {{ .Values.cron.suspend }}

--- a/chart/certbot/templates/cronjob.yaml
+++ b/chart/certbot/templates/cronjob.yaml
@@ -11,6 +11,9 @@ spec:
   jobTemplate:
     metadata:
       labels: {{ include "certbot.labels" . | nindent 8 }}
+{{- /*
+The certbot.jobSpec function is imported from the _helpers.tpl file, following the helm convention.
+*/}}
     spec: {{ include "certbot.jobSpec" . | nindent 6 }}
   schedule: {{ .Values.cron.schedule }}
   suspend: {{ .Values.cron.suspend }}

--- a/chart/certbot/templates/manual-job.yaml
+++ b/chart/certbot/templates/manual-job.yaml
@@ -6,5 +6,8 @@ metadata:
   labels: {{ include "certbot.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
+{{- /*
+The certbot.jobSpec function is imported from the _helpers.tpl file, following the helm convention.
+*/}}
 spec: {{ include "certbot.jobSpec" . | nindent 2 }}
 {{- end }}

--- a/chart/certbot/templates/manual-job.yaml
+++ b/chart/certbot/templates/manual-job.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.manualRun }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "certbot.fullname" . }}-manual
+  labels: {{ include "certbot.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+spec: {{ include "certbot.jobSpec" . | nindent 2 }}
+{{- end }}

--- a/chart/certbot/templates/pvc.yaml
+++ b/chart/certbot/templates/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "certbot.fullname" . }}
+  labels: {{ include "certbot.labels" . | nindent 4 }}
+spec:
+  storageClassName: netapp-file-standard
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 64Mi

--- a/chart/certbot/templates/rolebinding.yaml
+++ b/chart/certbot/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+groupNames: null
+metadata:
+  name: {{ template "certbot.fullname" . }}-edit
+  labels: {{ include "certbot.labels" . | nindent 4 }}
+roleRef:
+  name: edit
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "certbot.fullname" . }}

--- a/chart/certbot/templates/serviceaccount.yaml
+++ b/chart/certbot/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "certbot.fullname" . }}
+  labels: {{ include "certbot.labels" . | nindent 4 }}

--- a/chart/certbot/values.yaml
+++ b/chart/certbot/values.yaml
@@ -1,0 +1,35 @@
+
+image:
+  repository: bcgovimages/certbot
+  tag: latest
+  pullPolicy: Always
+
+artifactoryProxy:
+  enabled: false
+  artifactoryPrefix: artifacts.developer.gov.bc.ca/docker-remote
+  # You need to set this if you are using artifactoryProxy.enabled: true
+  artifactoryServiceAccount: ~
+
+certbot:
+  debug: false
+  # Self cleanup temporary ACME routes when done
+  deleteAcmeRoutes: true
+  dryRun: false
+  # Email where CSR requests are sent to. For Entrust, Product Owner's `*@gov.bc.ca` is suggested
+  email: ~
+  # Use self-signed cert renewals. Must be false if using Entrust
+  staging: false
+  # Staging Server: https://acme-staging-v02.api.letsencrypt.org/directory
+  # Entrust Server: https://www.entrust.net/acme/api/v1/directory/xx-xxxx-xxxx
+  server: https://acme-v02.api.letsencrypt.org/directory
+  # Allow domain validation to pass if a subset of them are vali
+  subset: true
+
+cron:
+  # Every Monday & Thursday - https://crontab.guru/#0_0_*_*_1,4
+  schedule: 0 0 * * 1,4
+  # In test environments, you might want to create the cronjob for consistency, but suspend it
+  suspend: false
+
+# Run the certbot job manually as a post-install/post-upgrade hook
+manualRun: false

--- a/chart/certbot/values.yaml
+++ b/chart/certbot/values.yaml
@@ -32,4 +32,6 @@ cron:
   suspend: false
 
 # Run the certbot job manually as a post-install/post-upgrade hook
+# Setting this to true is useful when you install your application chart,
+# so that the SSL cert is created automatically
 manualRun: false

--- a/chart/certbot/values.yaml
+++ b/chart/certbot/values.yaml
@@ -12,16 +12,25 @@ artifactoryProxy:
 
 certbot:
   debug: false
+  dryRun: false
+
   # Self cleanup temporary ACME routes when done
   deleteAcmeRoutes: true
-  dryRun: false
+
   # Email where CSR requests are sent to. For Entrust, Product Owner's `*@gov.bc.ca` is suggested
   email: ~
+
   # Use self-signed cert renewals. Must be false if using Entrust
   staging: false
+
   # Staging Server: https://acme-staging-v02.api.letsencrypt.org/directory
   # Entrust Server: https://www.entrust.net/acme/api/v1/directory/xx-xxxx-xxxx
+  # You can also retrieve the server from a secret:
+  # server:
+  #   secretName: your-acme-server-secret
+  #   secretKey: acme-server-url
   server: https://acme-v02.api.letsencrypt.org/directory
+
   # Allow domain validation to pass if a subset of them are vali
   subset: true
 


### PR DESCRIPTION
# Description

This PR adds a helm chart, allowing easy deployment of the certbot templates.
On top of the options already available with the openshift templates, this adds
 - support for downloading of the docker container via an artifactory proxy
 - support for manual run of the certbot job as a Helm post-install/post-upgrade hook, allowing automated certificate issuance within the application installation.
 - TODO: support for retrieval of ACME server value from a secret, as Entrust server URLs may be stored in a secret

## Types of changes

New feature, with accompanying documentation (PR is still in draft, so no documentation yet)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Ideally, we would be able to consume the helm chart via a helm chart repository hosted with GitHub pages. This will require that a maintainer enables GitHub pages for this repository, and pushes a commit on the `gh-pages` branch (creating an orphan `gh-pages` with an empty `Readme.md` file should do the trick. 
I can then add a github action that would automatically publish the Helm chart when changes are merged into `master` 