### PR TITLE
Chart releaser workflow should use `azure/setup-helm@v1`

### DIFF
--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -22,7 +22,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v2
+        uses: azure/setup-helm@v1
         with:
           version: v3.8.2
 

--- a/charts/certbot/values.yaml
+++ b/charts/certbot/values.yaml
@@ -1,4 +1,3 @@
-
 image:
   repository: bcgovimages/certbot
   tag: latest


### PR DESCRIPTION
Looks like @v2 isn't published yet.

This was tested on my fork, resulting in the chart repository being published at https://matthieu-foucault.github.io/certbot/index.yaml