### PR TITLE
feat(helm-chart): certbot uses least-privilege role

### DIFF
--- a/charts/certbot/Chart.yaml
+++ b/charts/certbot/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: certbot
 description: A Helm chart for the Common Services Certbot
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.0.0"

--- a/charts/certbot/templates/_helpers.tpl
+++ b/charts/certbot/templates/_helpers.tpl
@@ -131,7 +131,7 @@ template:
           - mountPath: /etc/letsencrypt
             name: certbot-config
     restartPolicy: Never
-    serviceAccountName: certbot
+    serviceAccountName: {{ template "certbot.fullname" . }}
     volumes:
       - name: certbot-config
         persistentVolumeClaim:

--- a/charts/certbot/templates/role.yaml
+++ b/charts/certbot/templates/role.yaml
@@ -1,0 +1,44 @@
+apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  labels: {{ include "certbot.labels" . | nindent 4 }}
+  annotations:
+    openshift.io/description: Least-privilege role for the Certbot job
+  name: {{ template "certbot.fullname" . }}
+rules:
+  - apiGroups:
+      - template.openshift.io
+    resources:
+      - processedtemplates
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - route.openshift.io
+      - ""
+    attributeRestrictions: null
+    resources:
+      - routes/custom-host
+    verbs:
+      - create

--- a/charts/certbot/templates/rolebinding.yaml
+++ b/charts/certbot/templates/rolebinding.yaml
@@ -2,11 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 groupNames: null
 metadata:
-  name: {{ template "certbot.fullname" . }}-edit
+  name: {{ template "certbot.fullname" . }}
   labels: {{ include "certbot.labels" . | nindent 4 }}
 roleRef:
-  name: edit
-  kind: ClusterRole
+  name: {{ template "certbot.fullname" . }}
+  kind: Role
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount

--- a/openshift/certbot.dc.yaml
+++ b/openshift/certbot.dc.yaml
@@ -13,13 +13,59 @@ objects:
     metadata:
       name: certbot
 
-  - apiVersion: v1
+  - apiVersion: authorization.openshift.io/v1
+    kind: Role
+    metadata:
+      annotations:
+        openshift.io/description: Least-privilege role for the Certbot job
+      name: certbot
+    rules:
+      - apiGroups:
+          - template.openshift.io
+        resources:
+          - processedtemplates
+        verbs:
+          - create
+      - apiGroups:
+          - ""
+        resources:
+          - services
+        verbs:
+          - list
+          - get
+          - create
+          - update
+          - patch
+          - delete
+      - apiGroups:
+          - route.openshift.io
+        resources:
+          - routes
+        verbs:
+          - list
+          - get
+          - create
+          - update
+          - patch
+          - delete
+      - apiGroups:
+          - route.openshift.io
+          - ""
+        attributeRestrictions: null
+        resources:
+          - routes/custom-host
+        verbs:
+          - create
+
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     groupNames: null
     metadata:
-      name: certbot_edit
+      name: certbot
     roleRef:
-      name: edit
+      name: certbot
+      kind: Role
+      apiGroup: rbac.authorization.k8s.io
     subjects:
       - kind: ServiceAccount
         name: certbot


### PR DESCRIPTION
# Description

Granting the `edit` cluster role to the certbot service account is incompatible with deployer service accounts following the least-privilege principle. This PR adds a custom role that only includes permissions on the objects needed by the certbot script (templates, routes and services).

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Version 0.1.1 of the chart was released in my fork, and we are manually testing this in the `cas-cif` project to ensure that this configuration works as expected.
Automated end-to-end tests of the certbot templates and various helm chart configurations could be added if this project was provided with a namespace set in the KLAB cluster. 
