### PR TITLE
Add support for managing a certificate per host

### DIFF
--- a/charts/certbot/templates/_helpers.tpl
+++ b/charts/certbot/templates/_helpers.tpl
@@ -122,6 +122,8 @@ template:
             value: {{ .Values.certbot.staging | quote }}
           - name: CERTBOT_SUBSET
             value: {{ .Values.certbot.subset | quote }}
+          - name: CERTBOT_CERT_PER_HOST
+            value: {{ .Values.certbot.certPerHost | quote }}
         resources:
           requests:
             cpu: 50m

--- a/charts/certbot/values.yaml
+++ b/charts/certbot/values.yaml
@@ -30,8 +30,12 @@ certbot:
   #   secretKey: acme-server-url
   server: https://acme-v02.api.letsencrypt.org/directory
 
-  # Allow domain validation to pass if a subset of them are vali
+  # Allow domain validation to pass if a subset of them are valid
   subset: true
+
+  # Manage an individual certificate per unique managed host (domain name), if true, 
+  # otherwise, manage a single certificate for all managed hosts (domain names)
+  certPerHost: false
 
 cron:
   # Every Monday & Thursday - https://crontab.guru/#0_0_*_*_1,4

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,17 +10,17 @@ To learn more about the **Common Services** available visit the [Common Services
 
 ## Table of Contents
 
-- [Summary](#summary)
-- [Environment Variables](#environment-variables)
-- [Quick Start](#quick-start)
-  - [Manual Run](#manual-run)
-  - [Cleanup](#cleanup)
-- [Entrust Usage](#entrust-usage)
-- [Tips](#tips)
-- [Appendix](#appendix)
-  - [References](#references)
-  - [Errata](#errata)
-- [License](#license)
+  - [Summary](#summary)
+  - [Environment Variables](#environment-variables)
+  - [Quick Start](#quick-start)
+    - [Manual Run](#manual-run)
+    - [Cleanup](#cleanup)
+  - [Entrust Usage](#entrust-usage)
+  - [Tips](#tips)
+  - [Appendix](#appendix)
+    - [References](#references)
+    - [Errata](#errata)
+  - [License](#license)
 
 ## Summary
 
@@ -29,7 +29,7 @@ To learn more about the **Common Services** available visit the [Common Services
 - Should only be executed on Openshift Container Platform
 - Creates an OpenShift `CronJob` which will run on a regular schedule for renewing TLS certificates
   - The `CronJob` will manage all `Route` objects annotated with the label `certbot-managed=true`
-  - One certificate will be issued/renewed for all the managed hosts/domains
+  - You have the option of a single certificate being issued/renewed for all the managed hosts/domains, or of an individual certificate being issued/renewed for each managed host/domain.
 - If a cert is created/renewed, patch the new certificate to the managed OpenShift routes
 
 ## Environment Variables
@@ -49,6 +49,7 @@ The Certbot container image supports an array of environment variables to config
 | `CERTBOT_RSA_KEY_SIZE` | `2048` | Key length for RSA keypair generation |
 | `CERTBOT_STAGING` | `false` | Use self-signed cert renewals. Must be `false` if using [Entrust](#entrust-usage)) |
 | `CERTBOT_SUBSET` | `true` | Allow Certbot to pass ACME challenge if at least one domain succeeds |
+| `CERTBOT_CERT_PER_HOST` | `false` | Manage an individual certificate per unique managed host (domain name), if true, otherwise, manage a single certificate for all managed hosts (domain names) |
 
 ## Quick Start
 
@@ -81,6 +82,7 @@ The following provides you a quick way to get Certbot set up and running as an O
     | `CERTBOT_SERVER` | `https://acme-v02.api.letsencrypt.org/directory` | ACME Certbot endpoint. For BC Gov SSL, see [Entrust](#entrust-usage). |
     | `CERTBOT_STAGING` | `false` | Use self-signed cert renewals. Must be `false` if using [Entrust](#entrust-usage)) |
     | `CERTBOT_SUBSET` | `true` | Allow domain validation to pass if a subset of them are valid |
+    | `CERTBOT_CERT_PER_HOST` | `false` | Manage an individual certificate per unique managed host (domain name), if true, otherwise, manage a single certificate for all managed hosts (domain names) |
     | `CRON_SCHEDULE` | `0 0 * * 1,4` | [Cronjob](https://crontab.guru) Schedule |
     | `CRON_SUSPEND` | `false` | Suspend cronjob |
     | `IMAGE_REGISTRY` | `docker.io` | Image Registry |

--- a/openshift/certbot.dc.yaml
+++ b/openshift/certbot.dc.yaml
@@ -134,6 +134,8 @@ objects:
                       value: "${CERTBOT_STAGING}"
                     - name: CERTBOT_SUBSET
                       value: "${CERTBOT_SUBSET}"
+                    - name: CERTBOT_CERT_PER_HOST
+                      value: "${CERTBOT_CERT_PER_HOST}"
                   resources:
                     requests:
                       cpu: 50m
@@ -187,6 +189,11 @@ parameters:
     description: Allow domain validation to pass if a subset of them are valid
     required: true
     value: "true"
+
+  - name: CERTBOT_CERT_PER_HOST
+    description: Manage an individual certificate per unique managed host (domain name), if true, otherwise, manage a single certificate for all managed hosts (domain names)
+    required: true
+    value: "false"
 
   - name: CRON_SCHEDULE
     description: Cronjob Schedule


### PR DESCRIPTION
# Description

Adds the option to have cerbot manage individual certificates for each unique managed domain name, rather than bundling them together under a single certificate.  This ensures the subject (CN) matches the domain name of the url, as opposed to just being the first domain name in the list of subject alternative names which may have little to no relation to other domain names in the list of managed routes.

This also opens up the option of incrementally adding additional managed routes to your environment over time.

## Types of changes

- New feature (non-breaking change which adds functionality)
- Documentation (non-breaking change with enhancements to documentation)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have tested the changes
- [x] I have added necessary documentation (if appropriate)