### PR TITLE
Update certbot readme's with entrust end of support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Certbot [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Lifecycle:Stable](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
+# Certbot [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Lifecycle:Dormant](https://img.shields.io/badge/Lifecycle-Dormant-ff7f2a)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 [![version](https://img.shields.io/docker/v/bcgovimages/certbot.svg?sort=semver)](https://hub.docker.com/r/bcgovimages/certbot)
 [![pulls](https://img.shields.io/docker/pulls/bcgovimages/certbot.svg)](https://hub.docker.com/r/bcgovimages/certbot)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Automatically update TLS Certificates on OpenShift Routes
 
+**Update: As of August 2023, Entrust (the only approved certificate provider for BC Gov production environments) has discontinued support for Certbot. Currently, Certbot cannot be used to manage your Entrust certificates.**
+
 To learn more about the **Common Services** available visit the [Common Services Showcase](https://bcgov.github.io/common-service-showcase/) page.
 
 ## Directory Structure

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,6 +6,8 @@
 
 Automatically update TLS Certificates on OpenShift Routes
 
+**Update: As of August 2023, Entrust (the only approved certificate provider for BC Gov production environments) has discontinued support for Certbot. Currently, Certbot cannot be used to manage your Entrust certificates.**
+
 To learn more about the **Common Services** available visit the [Common Services Showcase](https://bcgov.github.io/common-service-showcase/) page.
 
 ## Table of Contents
@@ -133,7 +135,11 @@ oc delete cronjob,pvc,rolebinding,sa -n $NAMESPACE -l app=certbot
 
 ## Entrust Usage
 
-Entrust is the only approved certificate provider for BC Gov production environments currently. There are a few extra steps required to request certificates from Entrust instead of LetsEncrypt.
+**Update: As of August 2023, BC Gov's security certificate supplier, Entrust, has discontinued support for Certbot. Currently, Certbot cannot be used to manage your Entrust certificates.**
+
+Entrust is the only approved certificate provider for BC Gov production environments currently.
+
+Where Entrust does support Certbot, there are a few extra steps required to request certificates from Entrust instead of LetsEncrypt.
 
 1. Start by creating the deployment config found in the [Quick Start](#quick-start) section
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
with Entrust dropping support for certbot (using the V1 entrust endpoint) we need to let BC users know Entrust is no longer an option for certs in a production environment.


## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
 Documentation (non-breaking change with enhancements to documentation) 
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->